### PR TITLE
Feature/broadcast wait

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -102,22 +102,24 @@ type SocketServer struct {
 	// maps clientID to roomID for direct client messaging
 	clientConnections  map[string]*connection
 	channels           map[string]*channel
+	waitingMsgs        *waitMessages
 	broadcastListeners map[string]sockets.HandlerFunc
 	directListeners    map[string]sockets.HandlerFunc
-	middleware         []sockets.MiddlewareFunc
-	errHandler         sockets.ServerErrorHandlerFunc
-	unregister         chan unregister
-	register           chan register
-	channelSender      chan sender
-	directSender       chan sender
-	close              chan struct{}
-	done               chan struct{}
-	channelCloser      chan string
-	opts               *opts
-	onRegister         func(clientID, channelID string)
-	onDeRegister       func(clientID, channelID string)
-	onChannelClose     func(channelID string)
-	onChannelCreate    func(channelID string)
+
+	middleware      []sockets.MiddlewareFunc
+	errHandler      sockets.ServerErrorHandlerFunc
+	unregister      chan unregister
+	register        chan register
+	channelSender   chan sender
+	directSender    chan sender
+	close           chan struct{}
+	done            chan struct{}
+	channelCloser   chan string
+	opts            *opts
+	onRegister      func(clientID, channelID string)
+	onDeRegister    func(clientID, channelID string)
+	onChannelClose  func(channelID string)
+	onChannelCreate func(channelID string)
 }
 
 // New will setup and return a new instance of a SocketServer.
@@ -131,6 +133,7 @@ func New(opts ...OptFunc) *SocketServer {
 	s := &SocketServer{
 		clientConnections:  make(map[string]*connection),
 		channels:           make(map[string]*channel),
+		waitingMsgs:        newWaitMessgaes(),
 		broadcastListeners: make(map[string]sockets.HandlerFunc),
 		directListeners:    make(map[string]sockets.HandlerFunc),
 		middleware:         make([]sockets.MiddlewareFunc, 0),
@@ -380,6 +383,13 @@ func (s *SocketServer) Listen(conn *websocket.Conn, channelID string) error {
 		m.ClientID = clientID
 		ctx := context.Background()
 		log.Debug().Msg("message received")
+		// if this is a wait message deliver it and move on
+		if wm := s.waitingMsgs.message(m.CorrelationID); wm != nil {
+			log.Debug().Msgf("wait message for correlationID %s executing", m.CorrelationID)
+			wm.deliver(m)
+			continue
+		}
+
 		hndlr, isDirect := s.handler(m.Key())
 		if hndlr == nil {
 			log.Debug().Msgf("no handler found for message %s", m.Key())
@@ -468,6 +478,19 @@ func (s *SocketServer) BroadcastDirect(clientID string, msg *sockets.Message) {
 		ID:  clientID,
 		msg: msg,
 	}
+}
+
+// BroadcastAndWait will send a broadcast to a channel and wait for a response,
+// this will simply act on the first response to hit the server, if multiple peers respond, only the
+// first will be returned.
+//
+// The function will return if a msg is returned OR an error is returned OR the ctx times out.
+func (s *SocketServer) BroadcastAndWait(ctx context.Context, channelID string, msg *sockets.Message) (*sockets.Message, error) {
+	defer s.waitingMsgs.delete(msg.CorrelationID)
+	wm := newWaitMessage()
+	s.waitingMsgs.add(msg.CorrelationID, wm)
+	s.Broadcast(channelID, msg)
+	return wm.wait(ctx)
 }
 
 // WithMiddleware will append the middleware funcs to any already registered middleware functions.

--- a/server/server.go
+++ b/server/server.go
@@ -480,12 +480,12 @@ func (s *SocketServer) BroadcastDirect(clientID string, msg *sockets.Message) {
 	}
 }
 
-// BroadcastAndWait will send a broadcast to a channel and wait for a response,
+// BroadcastAwait will send a broadcast to a channel and wait for a response,
 // this will simply act on the first response to hit the server, if multiple peers respond, only the
 // first will be returned.
 //
 // The function will return if a msg is returned OR an error is returned OR the ctx times out.
-func (s *SocketServer) BroadcastAndWait(ctx context.Context, channelID string, msg *sockets.Message) (*sockets.Message, error) {
+func (s *SocketServer) BroadcastAwait(ctx context.Context, channelID string, msg *sockets.Message) (*sockets.Message, error) {
 	defer s.waitingMsgs.delete(msg.CorrelationID)
 	wm := newWaitMessage()
 	s.waitingMsgs.add(msg.CorrelationID, wm)

--- a/server/wait.go
+++ b/server/wait.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/theflyingcodr/sockets"
+)
+
+type waitMessage struct {
+	errs chan error
+	msg  chan *sockets.Message
+}
+
+func newWaitMessage() *waitMessage {
+	return &waitMessage{
+		errs: make(chan error),
+		msg:  make(chan *sockets.Message),
+	}
+}
+
+func (w *waitMessage) deliver(msg *sockets.Message) {
+	w.msg <- msg
+}
+
+func (w *waitMessage) error(err error) {
+	w.errs <- err
+}
+
+func (w *waitMessage) wait(ctx context.Context) (*sockets.Message, error) {
+	defer func() {
+		close(w.errs)
+		close(w.msg)
+	}()
+	for {
+		select {
+		case msg := <-w.msg:
+			return msg, nil
+		case err := <-w.errs:
+			return nil, err
+		case <-ctx.Done():
+			return nil, errors.New("timeout waiting for message")
+		}
+	}
+}
+
+// waitMessages is a thread safe map wrapper.
+type waitMessages struct {
+	sync.RWMutex
+	msgs map[string]*waitMessage
+}
+
+func newWaitMessgaes() *waitMessages {
+	return &waitMessages{
+		RWMutex: sync.RWMutex{},
+		msgs:    make(map[string]*waitMessage),
+	}
+}
+
+func (w *waitMessages) message(correlationID string) *waitMessage {
+	w.RLock()
+	defer w.RUnlock()
+	return w.msgs[correlationID]
+}
+
+func (w *waitMessages) add(correlationID string, wm *waitMessage) {
+	w.Lock()
+	defer w.Unlock()
+	w.msgs[correlationID] = wm
+}
+
+func (w *waitMessages) delete(correlationID string) {
+	w.Lock()
+	defer w.Unlock()
+	delete(w.msgs, correlationID)
+}

--- a/server/wait.go
+++ b/server/wait.go
@@ -24,10 +24,6 @@ func (w *waitMessage) deliver(msg *sockets.Message) {
 	w.msg <- msg
 }
 
-func (w *waitMessage) error(err error) {
-	w.errs <- err
-}
-
 func (w *waitMessage) wait(ctx context.Context) (*sockets.Message, error) {
 	defer func() {
 		close(w.errs)

--- a/socket.go
+++ b/socket.go
@@ -1,6 +1,7 @@
 package sockets
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"reflect"
@@ -35,7 +36,12 @@ type ServerDirectBroadcaster interface {
 
 // ServerChannelBroadcaster is used to send a message from a server to all clients connected to a channel.
 type ServerChannelBroadcaster interface {
+	// Broadcast will send a message to all connected peers on a channel.
+	// To handle these messages you should register a handler using server.RegisterChannelHandler.
 	Broadcast(channelID string, msg *Message)
+	// BroadcastAndWait will broadcast a message to all peers but handle only the first one and return
+	// it to the caller. This is a blocking call.
+	BroadcastAndWait(ctx context.Context, channelID string, msg *Message) (*Message, error)
 }
 
 // Request is used to send a message to a channel with a specific key.

--- a/socket.go
+++ b/socket.go
@@ -39,9 +39,9 @@ type ServerChannelBroadcaster interface {
 	// Broadcast will send a message to all connected peers on a channel.
 	// To handle these messages you should register a handler using server.RegisterChannelHandler.
 	Broadcast(channelID string, msg *Message)
-	// BroadcastAndWait will broadcast a message to all peers but handle only the first one and return
+	// BroadcastAwait will broadcast a message to all peers but handle only the first one and return
 	// it to the caller. This is a blocking call.
-	BroadcastAndWait(ctx context.Context, channelID string, msg *Message) (*Message, error)
+	BroadcastAwait(ctx context.Context, channelID string, msg *Message) (*Message, error)
 }
 
 // Request is used to send a message to a channel with a specific key.


### PR DESCRIPTION
Adds a new feature that allows a server to broadcast and then wait on a response from a peer, using correlationID as the identifier.