### PR TITLE
Fix: Hang when awaiting for non-extant channel

### DIFF
--- a/client/connections.go
+++ b/client/connections.go
@@ -128,7 +128,9 @@ func (c *Client) reconnect(url string) (*websocket.Conn, bool) {
 			}
 			continue
 		}
-		defer resp.Body.Close()
+		defer func() {
+			_ = resp.Body.Close()
+		}()
 		return ws, true
 	}
 }

--- a/client/connections.go
+++ b/client/connections.go
@@ -120,7 +120,7 @@ func (c *Client) reconnect(url string) (*websocket.Conn, bool) {
 	for {
 		i++
 		time.Sleep(c.opts.reconnectTimeout)
-		ws, _, err := websocket.DefaultDialer.Dial(url, nil)
+		ws, resp, err := websocket.DefaultDialer.Dial(url, nil)
 		if err != nil {
 			log.Err(err).Msgf("failed to reconnect to '%s' after '%d' attempts", url, i)
 			if c.opts.reconnectAttempts != -1 && i > c.opts.reconnectAttempts {
@@ -128,6 +128,7 @@ func (c *Client) reconnect(url string) (*websocket.Conn, bool) {
 			}
 			continue
 		}
+		defer resp.Body.Close()
 		return ws, true
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,6 @@
+package sockets
+
+import "errors"
+
+// ErrChannelNotFound returned when channel is not found.
+var ErrChannelNotFound = errors.New("channel not found")

--- a/examples/clientserver/client.go
+++ b/examples/clientserver/client.go
@@ -37,7 +37,7 @@ func SetupClient() *client.Client {
 	})
 
 	for i := 0; i < 2000; i++ {
-		if err := c.JoinChannel(u.String(), fmt.Sprintf("test-channel-%d", i), h); err != nil {
+		if err := c.JoinChannel(u.String(), fmt.Sprintf("test-channel-%d", i), h, nil); err != nil {
 			log.Fatal().Err(err).Msg("CLIENT failed to join channel")
 		}
 		go func(id int) {

--- a/examples/simple/client.go
+++ b/examples/simple/client.go
@@ -37,7 +37,7 @@ func setupClient() *sockets2.Client {
 		return msg.NoContent()
 	})
 
-	if err := client.JoinChannel(u.String(), "test-channel", h); err != nil {
+	if err := client.JoinChannel(u.String(), "test-channel", h, nil); err != nil {
 		log.Fatal().Err(err).Msg("CLIENT failed to join channel")
 	}
 	go func() {

--- a/server/server.go
+++ b/server/server.go
@@ -487,7 +487,7 @@ func (s *SocketServer) BroadcastDirect(clientID string, msg *sockets.Message) {
 
 // HasChannel will check to see if the server has a channel connection established.
 func (s *SocketServer) HasChannel(channelID string) bool {
-	log.Info().Msgf("checking if channel %s exists", channelID)
+	log.Debug().Msgf("checking if channel %s exists", channelID)
 	exists := make(chan bool)
 	defer close(exists)
 
@@ -497,7 +497,7 @@ func (s *SocketServer) HasChannel(channelID string) bool {
 	}
 
 	result := <-exists
-	log.Info().Msgf("channel %s exists: %t", channelID, result)
+	log.Debug().Msgf("channel %s exists: %t", channelID, result)
 	return result
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -112,6 +112,7 @@ type SocketServer struct {
 	register        chan register
 	channelSender   chan sender
 	directSender    chan sender
+	channelChecker  chan checker
 	close           chan struct{}
 	done            chan struct{}
 	channelCloser   chan string
@@ -142,6 +143,7 @@ func New(opts ...OptFunc) *SocketServer {
 		register:           make(chan register, 1),
 		channelSender:      make(chan sender, 256),
 		directSender:       make(chan sender, 256),
+		channelChecker:     make(chan checker, 256),
 		close:              make(chan struct{}, 1),
 		done:               make(chan struct{}, 1),
 		opts:               defaults,
@@ -258,6 +260,9 @@ func (s *SocketServer) channelManager() {
 				}
 				go func() { ch.send <- m.msg }()
 			}
+		case c := <-s.channelChecker:
+			_, ok := s.channels[c.ID]
+			c.exists <- ok
 		case <-ticker.C:
 			for channelID, channel := range s.channels {
 				if channel.expires.IsZero() { // doesn't expire
@@ -480,12 +485,34 @@ func (s *SocketServer) BroadcastDirect(clientID string, msg *sockets.Message) {
 	}
 }
 
+// HasChannel will check to see if the server has a channel connection established.
+func (s *SocketServer) HasChannel(channelID string) bool {
+	log.Info().Msgf("checking if channel %s exists", channelID)
+	exists := make(chan bool)
+	defer close(exists)
+
+	s.channelChecker <- checker{
+		ID:     channelID,
+		exists: exists,
+	}
+
+	log.Info().Msgf("waiting on response for channel %s", channelID)
+
+	result := <-exists
+	log.Info().Msgf("channel %s exists: %t", channelID, result)
+
+	return result
+}
+
 // BroadcastAwait will send a broadcast to a channel and wait for a response,
 // this will simply act on the first response to hit the server, if multiple peers respond, only the
 // first will be returned.
 //
 // The function will return if a msg is returned OR an error is returned OR the ctx times out.
 func (s *SocketServer) BroadcastAwait(ctx context.Context, channelID string, msg *sockets.Message) (*sockets.Message, error) {
+	if !s.HasChannel(channelID) {
+		return nil, sockets.ErrChannelNotFound
+	}
 	defer s.waitingMsgs.delete(msg.CorrelationID)
 	wm := newWaitMessage()
 	s.waitingMsgs.add(msg.CorrelationID, wm)
@@ -520,4 +547,9 @@ type unregister struct {
 type sender struct {
 	ID  string
 	msg interface{}
+}
+
+type checker struct {
+	ID     string
+	exists chan bool
 }

--- a/server/server.go
+++ b/server/server.go
@@ -496,11 +496,8 @@ func (s *SocketServer) HasChannel(channelID string) bool {
 		exists: exists,
 	}
 
-	log.Info().Msgf("waiting on response for channel %s", channelID)
-
 	result := <-exists
 	log.Info().Msgf("channel %s exists: %t", channelID, result)
-
 	return result
 }
 

--- a/socket.go
+++ b/socket.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 )
 
 // common headers.
@@ -221,8 +222,12 @@ type ErrorMessage struct {
 // There is a default sockets.ErrorDetail struct available, or you can define your own.
 func (m *Message) ToError(err interface{}) *ErrorMessage {
 	var bb []byte
+	var mErr error
 	if !isNil(err) {
-		bb, _ = json.Marshal(err)
+		bb, mErr = json.Marshal(err)
+		if mErr != nil {
+			log.Error().Err(mErr)
+		}
 	}
 	e := &ErrorMessage{
 		CorrelationID: m.CorrelationID,

--- a/socket.go
+++ b/socket.go
@@ -18,7 +18,7 @@ const (
 // Client can be used to implement a client which will send and listen
 // to messages on channels.
 type Client interface {
-	JoinChannel(host, channelID string, headers http.Header) error
+	JoinChannel(host, channelID string, headers http.Header, params map[string]string) error
 	LeaveChannel(channelID string, headers http.Header)
 	RegisterListener(msgType string, fn HandlerFunc)
 }


### PR DESCRIPTION
Currently broadcast await hangs if waiting on a channel which doesn't exist. To address this I've:
1. Added a checker channel, which just `ok` checks the channels map
2. Created a HasChannel function, which uses this channel to existence check via channel id.
3. Call this HasChannel function at the start of broadcast await.

Also, I had added the ability to send query params when joining a channel.